### PR TITLE
支持手动设置WAF页面的状态码

### DIFF
--- a/cmd/blazehttp/main.go
+++ b/cmd/blazehttp/main.go
@@ -28,6 +28,7 @@ var (
 	c                 = 10   // default 10 concurrent workers
 	mHost             string // modify host header
 	requestPerSession bool   // send request per session
+	wafStatusCode     int    // manually specify WAF block status code
 )
 
 func init() {
@@ -41,6 +42,7 @@ func init() {
 	flag.IntVar(&timeout, "timeout", 1000, "connection timeout, default 1000 ms")
 	flag.StringVar(&mHost, "H", "", "modify host header")
 	flag.BoolVar(&requestPerSession, "rps", true, "send request per session")
+	flag.IntVar(&wafStatusCode, "w", 0, "manually specify WAF block status code (0 means auto-detect)")
 	flag.Parse()
 	if url, err := url.Parse(target); err != nil || url.Scheme == "" || url.Host == "" {
 		fmt.Println("invalid target url, example: http://chaitin.com:9443")
@@ -60,14 +62,23 @@ func main() {
 		addr = u.Host
 	}
 
-	isWaf, blockStatusCode, err := utils.GetWafBlockStatusCode(target, mHost)
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-	if !isWaf {
-		fmt.Println("目标网站未开启waf")
-		os.Exit(1)
+	var blockStatusCode int
+	if wafStatusCode != 0 {
+		// Use manually specified WAF status code
+		blockStatusCode = wafStatusCode
+		fmt.Printf("使用手动指定的WAF状态码: %d\n", blockStatusCode)
+	} else {
+		// Auto-detect WAF status code
+		isWaf, detectedStatusCode, err := utils.GetWafBlockStatusCode(target, mHost)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		if !isWaf {
+			fmt.Println("目标网站未开启waf")
+			os.Exit(1)
+		}
+		blockStatusCode = detectedStatusCode
 	}
 
 	fileList := make([]string, 0)

--- a/gui/main.go
+++ b/gui/main.go
@@ -251,7 +251,7 @@ func MakeRunForm(w fyne.Window, outputCh chan string, resultCh chan *worker.Resu
 
 	// timeout
 	statusCode := widget.NewEntry()
-	statusCode.SetText("403")
+	statusCode.SetText("0")
 	statusCode.Validator = validation.NewRegexp(`^\d+$`, "StatusCode必须是数字")
 
 	advanceForm := &widget.Form{
@@ -472,15 +472,20 @@ func run(target, mHost string, c, statusCode int, resultCh chan *worker.Result, 
 		addr = u.Host
 	}
 
-	isWaf, blockStatusCode, err := utils.GetWafBlockStatusCode(target, mHost)
-	if err != nil {
-		return err
-	}
-	if !isWaf {
-		return errors.New("目标网站未开启waf")
-	}
-	if blockStatusCode != statusCode {
-		return fmt.Errorf("探测到拦截状态码: %d 与配置拦截状态码: %d 不一致", blockStatusCode, statusCode)
+	var blockStatusCode int
+	if statusCode != 0 {
+		// 使用手动指定的WAF状态码
+		blockStatusCode = statusCode
+	} else {
+		// 自动检测WAF状态码
+		isWaf, detectedStatusCode, err := utils.GetWafBlockStatusCode(target, mHost)
+		if err != nil {
+			return err
+		}
+		if !isWaf {
+			return errors.New("目标网站未开启waf")
+		}
+		blockStatusCode = detectedStatusCode
 	}
 
 	worker := worker.NewWorker(


### PR DESCRIPTION
现在blazehttp会自动检测WAF页面的状态码，但CLI和GUI对这个功能的支持有些差异

CLI只支持自动检测，不支持手动指定WAF页面的状态码

GUI支持手动指定WAF页面的状态码，但是指定的状态码和自动检测得到的状态码不同则停止检测

这个PR给CLI加上了`-w`选项支持手动指定状态码，同时将GUI改为直接使用指定的状态码进行检测