### PR TITLE
修复 Content-Length 设置的bug

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -210,7 +211,16 @@ func (w *Worker) runWorker() {
 				req.SetHeader("Connection", "close")
 			}
 
-			req.CalculateContentLength()
+			// 目前样本中没有使用Transfer-Encoding: chunked的，但是为了自定义样本需要更小心地设置Content-Length
+			// 参考: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Length
+			is_http1_1, err := regexp.Match("[A-Z]+ [^ ]+ HTTP/1.1", req.RequestLine)
+			if err != nil {
+				job.Result.Err = fmt.Sprintf("parse request failed, error: %s", err)
+				return
+			}
+			if is_http1_1 && !strings.Contains(req.GetHeader("Transfer-Encoding"), "chunked") {
+				req.CalculateContentLength()
+			}
 
 			start := time.Now()
 			conn := blazehttp.Connect(w.addr, w.isHttps, w.timeout)


### PR DESCRIPTION
现在blazehttp在发送请求的时候总是会设置`Content-Length` header

但是根据[文档](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Length)，这个Header只有在HTTP 1.1且没有使用`Transfer-Encoding: chunked`的时候才应该被设置

虽然现在的样本中没有使用`Transfer-Encoding`的地方，但是为了自定义样本不出错仍然需要修复这个Bug